### PR TITLE
Adding contribution guide to the Openmadness project (Group 2)

### DIFF
--- a/group2-docs/docs/contribution-guide.md
+++ b/group2-docs/docs/contribution-guide.md
@@ -1,0 +1,33 @@
+---
+lang: en-US
+title: Contributing Guide
+description: This is the contributing guide for the Openmadness project
+---
+
+# Contributing Guide
+
+Thank you for your interest in contributing! This library is built to support developers and curious minds working with mathematical functions in JavaScript. 
+Contributions of all kinds are welcome — whether you’re fixing a bug, improving documentation, writing tests, or adding new features.
+You don’t need to be an expert to get involved. Clear code, helpful feedback, and thoughtful questions are all valuable contributions.
+This guide will walk you through how to get started. Let’s improve things together.
+
+## Reporting bugs and making feature requests
+
+Anyone can contribute to the Openmadness project - both beginners and experienced developers alike. 
+If you’ve found a bug or have an idea for a new feature, please open an issue with a clear description and, if possible, steps to reproduce or example use cases. This helps us understand and prioritise improvements more effectively.
+
+::: tip All details on how to contribute can be found in our README.md.
+:::
+
+## Code of Conduct
+
+We are committed to providing a welcoming and inclusive environment for everyone, regardless of age, background, identity, or experience level.
+We expect all participants to:
+- Be respectful, kind, and constructive.
+- Welcome diverse viewpoints and experiences.
+- Communicate with empathy and professionalism.
+- Accept feedback gracefully and offer it thoughtfully.
+
+Unacceptable behaviour—such as harassment, discrimination, or personal attacks—will not be tolerated in any form.
+If you observe or experience a violation of this Code of Conduct, please contact the maintainers at [bravo@openmadness.com]. All reports will be handled confidentially.
+This project follows the [Contributor Covenant v2.1.](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)


### PR DESCRIPTION
Adding the contribution guide. There is 1 pending thing: adding a link to the Readme once it is available.