### PR TITLE
docs(group-2): add edit buttons

### DIFF
--- a/group2-docs/docs/.vuepress/config.js
+++ b/group2-docs/docs/.vuepress/config.js
@@ -1,18 +1,31 @@
-import { defaultTheme } from '@vuepress/theme-default'
-import { defineUserConfig } from 'vuepress'
-import { viteBundler } from '@vuepress/bundler-vite'
+import { defaultTheme } from "@vuepress/theme-default";
+import { defineUserConfig } from "vuepress";
+import { viteBundler } from "@vuepress/bundler-vite";
 
 export default defineUserConfig({
-  lang: 'en-US',
+	lang: "en-US",
 
-  title: 'VuePress',
-  description: 'My first VuePress Site',
+	title: "VuePress",
+	description: "My first VuePress Site",
 
-  theme: defaultTheme({
-    logo: 'https://vuejs.press/images/hero.png',
+	theme: defaultTheme({
+		logo: "https://vuejs.press/images/hero.png",
 
-    navbar: ['/', '/get-started', '/tutorials', '/guides', '/om-functions', '/resources', '/changelog' ],
-  }),
+		navbar: [
+			"/",
+			"/get-started",
+			"/tutorials",
+			"/guides",
+			"/om-functions",
+			"/resources",
+			"/changelog",
+		],
+		editLink: true,
+		editLinkText: "Edit this page on GitHub",
+		docsRepo: "CBID2/TMP-group-docs-assignment-1",
+		docsDir: "group2-docs/docs",
+		docsBranch: "main",
+	}),
 
-  bundler: viteBundler(),
-})
+	bundler: viteBundler(),
+});


### PR DESCRIPTION
## Description

This pull request adds "Edit This Page on GitHub" button. I found this feature to be beneficial because it would make the editing process easier.

## Screenshot
![screenshot of "Edit This Page on GitHub" button on page of documentation](https://github.com/user-attachments/assets/680da437-9966-46a0-b2cb-6d4b6b10c60c)


> [!NOTE]  
> Necessary changes will need to be made to fit the main repo(for example, the names of the `main` and `docsRepo` section). Refer to the [Edit Link tutorial](https://theme-hope.vuejs.press/guide/feature/meta.html#edit-link) for more context. 
