### PR TITLE
docs: adding missing hyperlinks

### DIFF
--- a/group2-docs/docs/get-started.md
+++ b/group2-docs/docs/get-started.md
@@ -75,7 +75,7 @@ In this example, we:
 
 Congratulations! You just created your first simulation! 👍 Now that you have gotten the basics down, consider picking the following:
 
-* Guides  
-* Tutorials
+* [Guides](/group2-docs/docs/guides.md)
+* [Tutorials](/group2-docs/docs/tutorials.md)
 
 Got any ideas to improve the guide, check out our CONTRIBUTING guide on GitHub.


### PR DESCRIPTION
### Description
This pull request hyperlink the Guides and Tutorials in the Quickstart guide.

### Screenshot
![screenshot of change](https://github.com/user-attachments/assets/4c0f04f7-f8af-4a7c-888c-5e3e5f5b5129)
